### PR TITLE
Added a custom serializer

### DIFF
--- a/kong-plugin-argonath-kenny-loggins-0.0.0-1.rockspec
+++ b/kong-plugin-argonath-kenny-loggins-0.0.0-1.rockspec
@@ -14,6 +14,7 @@ build = {
    type = "builtin",
    modules = {
       ["kong.plugins.argonath-kenny-loggins.handler"] = "src/handler.lua",
-      ["kong.plugins.argonath-kenny-loggins.schema"] = "src/schema.lua"
+      ["kong.plugins.argonath-kenny-loggins.schema"] = "src/schema.lua",
+      ["kong.plugins.argonath-kenny-loggins.serializer"] = "src/serializer.lua"
    }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "argonath-kenny-loggins",
+  "name": "@cloudelements/argonath-kenny-loggins",
   "version": "0.0.0",
   "description": "A Kong plugin to handle Cloud Elements audit logging",
   "main": "index.js",

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -9,9 +9,9 @@ local l_log = lsyslog.log
 local string_upper = string.upper
 
 
-local SysLogHandler = BasePlugin:extend()
+local ArgonathKennyLogginsHandler = BasePlugin:extend()
 
-SysLogHandler.PRIORITY = 1
+ArgonathKennyLogginsHandler.PRIORITY = 1
 
 local SENDER_NAME = "kong"
 
@@ -45,12 +45,12 @@ local function log(premature, conf, message)
   end
 end
 
-function SysLogHandler:new()
-  SysLogHandler.super.new(self, "argonath-kenny-loggins")
+function ArgonathKennyLogginsHandler:new()
+  ArgonathKennyLogginsHandler.super.new(self, "argonath-kenny-loggins")
 end
 
-function SysLogHandler:log(conf)
-  SysLogHandler.super.log(self)
+function ArgonathKennyLogginsHandler:log(conf)
+  ArgonathKennyLogginsHandler.super.log(self)
 
   local message = basic_serializer.serialize(ngx)
   local ok, err = ngx_timer_at(0, log, conf, message)
@@ -59,4 +59,4 @@ function SysLogHandler:log(conf)
   end
 end
 
-return SysLogHandler
+return ArgonathKennyLogginsHandler

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -1,7 +1,7 @@
 local lsyslog = require "lsyslog"
 local cjson = require "cjson"
 local BasePlugin = require "kong.plugins.base_plugin"
-local basic_serializer = require "kong.plugins.log-serializers.basic"
+local serializer = require "kong.plugins.argonath-kenny-loggins.serializer"
 local ngx_log = ngx.log
 local ngx_timer_at = ngx.timer.at
 local l_open = lsyslog.open
@@ -52,7 +52,7 @@ end
 function ArgonathKennyLogginsHandler:log(conf)
   ArgonathKennyLogginsHandler.super.log(self)
 
-  local message = basic_serializer.serialize(ngx)
+  local message = serializer.serialize(ngx)
   local ok, err = ngx_timer_at(0, log, conf, message)
   if not ok then
     ngx_log(ngx.ERR, "failed to create timer: ", err)

--- a/src/serializer.lua
+++ b/src/serializer.lua
@@ -1,0 +1,46 @@
+local tablex = require "pl.tablex"
+
+local _M = {}
+
+local EMPTY = tablex.readonly({})
+
+function _M.serialize(ngx)
+  local authenticated_entity
+  if ngx.ctx.authenticated_credential ~= nil then
+    authenticated_entity = {
+      id = ngx.ctx.authenticated_credential.id,
+      consumer_id = ngx.ctx.authenticated_credential.consumer_id
+    }
+  end
+  
+  return {
+    request = {
+      uri = ngx.var.request_uri,
+      request_uri = ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri,
+      querystring = ngx.req.get_uri_args(), -- parameters, as a table
+      method = ngx.req.get_method(), -- http method
+      headers = ngx.req.get_headers(),
+      size = ngx.var.request_length
+    },
+    response = {
+      status = ngx.status,
+      headers = ngx.resp.get_headers(),
+      size = ngx.var.bytes_sent
+    },
+    tries = (ngx.ctx.balancer_address or EMPTY).tries,
+    latencies = {
+      kong = (ngx.ctx.KONG_ACCESS_TIME or 0) +
+             (ngx.ctx.KONG_RECEIVE_TIME or 0) +
+             (ngx.ctx.KONG_REWRITE_TIME or 0),
+      proxy = ngx.ctx.KONG_WAITING_TIME or -1,
+      request = ngx.var.request_time * 1000
+    },
+    authenticated_entity = authenticated_entity,
+    api = ngx.ctx.api,
+    consumer = ngx.ctx.authenticated_consumer,
+    client_ip = ngx.var.remote_addr,
+    started_at = ngx.req.start_time() * 1000
+  }
+end
+
+return _M

--- a/src/serializer.lua
+++ b/src/serializer.lua
@@ -12,6 +12,10 @@ function _M.serialize(ngx)
       consumer_id = ngx.ctx.authenticated_credential.consumer_id
     }
   end
+
+  local headers = ngx.req.get_headers()
+  headers["authorization"] = nil
+  headers["cookie"] = nil
   
   return {
     request = {
@@ -19,7 +23,7 @@ function _M.serialize(ngx)
       request_uri = ngx.var.scheme.."://"..ngx.var.host..":"..ngx.var.server_port..ngx.var.request_uri,
       querystring = ngx.req.get_uri_args(), -- parameters, as a table
       method = ngx.req.get_method(), -- http method
-      headers = ngx.req.get_headers(),
+      headers = headers,
       size = ngx.var.request_length
     },
     response = {

--- a/test/log_spec.lua
+++ b/test/log_spec.lua
@@ -72,6 +72,8 @@ describe("#ci Plugin: argonath-kenny-loggins (log)", function()
 
   local function do_test(host, expecting_same)
     local uuid = utils.random_string()
+    local auth = "abc"
+    local cookie = "xyz"
 
     local response = assert(client:send {
       method = "GET",
@@ -79,9 +81,13 @@ describe("#ci Plugin: argonath-kenny-loggins (log)", function()
       headers = {
         host = host,
         sys_log_uuid = uuid,
+        authorization = auth,
+        cookie = cookie
       }
     })
     assert.res_status(200, response)
+    assert.falsy(json.request.headers["authorization"])
+    assert.fasly(json.request.headers["cookie"])
 
     if platform == "Darwin" then
       local _, _, stdout = assert(helpers.execute("argonath-kenny-loggins -k Sender kong | tail -1"))


### PR DESCRIPTION
## Highlights

* Cloned v0.10.3 of the `syslog` kong plugin and renamed the module (left side of the diff)
* Added a custom serializer so user Auth tokens are not logged, this is pretty much just kong's `basic_serializer`
   * __note__: I tested the serializer with the `file-log` plugin, because I cannot for the life of me find where `stdout` is logging to on my system. Kong is a daemonized process so I can't see it in the terminal and it sure as heck is not logging to the usual places. I can see that it is actually logging in the kong logs, just not what it logs. 